### PR TITLE
gui-1.pngとgui-2.pngのパスを相対パスに修正

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -90,7 +90,7 @@ Compress-Archive -Path .\app\* -DestinationPath .\app.zip
 https://portal.hiyori.cloud/ にアクセスします。
 
 <img 
-  src="/img/gui-1.png" 
+  src="img/gui-1.png" 
   alt="アップロード画面" 
   width="600" 
   style={{
@@ -107,7 +107,7 @@ zipファイルの選択とデータベースオプションの選択ができ�
 デプロイされたアプリケーションのURLが表示されます。  
 
 <img 
-  src="/img/gui-2.png" 
+  src="img/gui-2.png" 
   alt="アップロード画面" 
   width="600" 
   style={{


### PR DESCRIPTION
追加頂いたGUI画像のパスが絶対パスだったため、GitHubPagesにデプロイ時に表示されなくなっている。
そのため、パスを相対パスに修正した。
hiyoriのロゴも「img/hiyori-logo.png」で指定しているので表示される想定。